### PR TITLE
🐛 fix(rope): correct push constant layout and base type handling

### DIFF
--- a/src/core/vkllm_pipeline.c
+++ b/src/core/vkllm_pipeline.c
@@ -534,7 +534,7 @@ static vkllm_err_t vkllm_create_matmul_pipelines(struct vkllm_context *context)
 static vkllm_err_t vkllm_create_rope_pipelines(struct vkllm_context *context)
 {
     struct vkllm_shader_info shader_info = {.binding_count = 2,
-                                            .push_constant_bytes = sizeof(uint32_t) * 9 + sizeof(float),
+                                            .push_constant_bytes = sizeof(uint32_t) * 17 + sizeof(float),
                                             .local_x = 512,
                                             .local_y = 1,
                                             .local_z = 1};
@@ -558,7 +558,6 @@ static vkllm_err_t vkllm_create_rope_pipelines(struct vkllm_context *context)
 
             if (context->device->support_fp16_arithmetic)
             {
-                shader_info.push_constant_bytes = sizeof(uint32_t) * 9 + 2 * sizeof(uint16_t);
                 _CHECK(vkllm_pipeline_new(context, "pipeline_rope_f16f16", shader_info, _vkllm_rope_f16f16_spv(),
                                           _vkllm_rope_f16f16_size(), specializations,
                                           &context->pipelines.rope.f16f16[i]));

--- a/src/shaders/vkllm_rope.comp
+++ b/src/shaders/vkllm_rope.comp
@@ -16,7 +16,7 @@ layout(push_constant) uniform constants
     ShapeConstant in_shape;
     ShapeConstant out_shape;
     uint offsets;
-    LOAD_DTYPE base;
+    float base;
 };
 
 layout(constant_id = 0) const int neox_style = 0;
@@ -65,7 +65,7 @@ void main(void)
         o1 = o0 + out_shape.strides[3];
     }
 
-    LOAD_DTYPE f = LOAD_DTYPE(offsets + h) / pow(base, LOAD_DTYPE(2 * w) / LOAD_DTYPE(in_shape.shapes[3]));
+    LOAD_DTYPE f = LOAD_DTYPE(offsets + h) / pow(LOAD_DTYPE(base), LOAD_DTYPE(2 * w) / LOAD_DTYPE(in_shape.shapes[3]));
     LOAD_DTYPE freqc = cos(f);
     LOAD_DTYPE freqs = sin(f);
 


### PR DESCRIPTION
- Fixed push constant size calculation in `vkllm_pipeline.c` to match the actual struct size (17 uints + 1 float).
- Changed `base` type to `float` in the shader and added explicit casting to `LOAD_DTYPE`.
- Unified the push constant size definition for both fp16 and fp32 paths.