### PR TITLE
🐛 fix(pipeline): Fix pipeline name allocation and RoPE push constants.

### DIFF
--- a/src/core/vkllm_pipeline.c
+++ b/src/core/vkllm_pipeline.c
@@ -181,7 +181,7 @@ vkllm_err_t vkllm_pipeline_new(struct vkllm_context *context, const char *name, 
         return VKLLM_ERR_ARGS;
     }
 
-    size_t name_len = name ? strlen(name) : 0;
+    size_t name_len = name ? strlen(name) + 1 : 0;
     *pipeline = (struct vkllm_pipeline *)malloc(sizeof(struct vkllm_pipeline) + name_len);
 
     struct vkllm_pipeline *p = *pipeline;
@@ -493,7 +493,7 @@ static vkllm_err_t vkllm_create_matmul_pipelines(struct vkllm_context *context)
 static vkllm_err_t vkllm_create_rope_pipelines(struct vkllm_context *context)
 {
     struct vkllm_shader_info shader_info = {.binding_count = 2,
-                                            .push_constant_bytes = sizeof(uint32_t) * 9 + sizeof(float),
+                                            .push_constant_bytes = sizeof(uint32_t) * 17 + sizeof(float),
                                             .local_x = 512,
                                             .local_y = 1,
                                             .local_z = 1};
@@ -517,7 +517,6 @@ static vkllm_err_t vkllm_create_rope_pipelines(struct vkllm_context *context)
 
             if (context->device->support_fp16_arithmetic)
             {
-                shader_info.push_constant_bytes = sizeof(uint32_t) * 9 + 2 * sizeof(uint16_t);
                 _CHECK(vkllm_pipeline_new(context, "pipeline_rope_f16f16", shader_info, _vkllm_rope_f16f16_spv(),
                                           _vkllm_rope_f16f16_size(), specializations,
                                           &context->pipelines.rope.f16f16[i]));

--- a/src/core/vkllm_pipeline.h
+++ b/src/core/vkllm_pipeline.h
@@ -37,7 +37,7 @@ struct vkllm_pipeline
     VkDescriptorSetLayout vk_desc_set_layout;
     VkDescriptorPool vk_desc_pool;
     VkQueryPool vk_query_pool;
-    const char *name[];
+    char *name[];
 };
 
 extern vkllm_err_t vkllm_shader_constants_new(struct vkllm_shader_constants **constants, uint32_t init_bytes);

--- a/src/shaders/vkllm_rope.comp
+++ b/src/shaders/vkllm_rope.comp
@@ -16,7 +16,7 @@ layout(push_constant) uniform constants
     ShapeConstant in_shape;
     ShapeConstant out_shape;
     uint offsets;
-    LOAD_DTYPE base;
+    float base;
 };
 
 layout(constant_id = 0) const int neox_style = 0;
@@ -65,7 +65,7 @@ void main(void)
         o1 = o0 + out_shape.strides[3];
     }
 
-    LOAD_DTYPE f = LOAD_DTYPE(offsets + h) / pow(base, LOAD_DTYPE(2 * w) / LOAD_DTYPE(in_shape.shapes[3]));
+    LOAD_DTYPE f = LOAD_DTYPE(offsets + h) / pow(LOAD_DTYPE(base), LOAD_DTYPE(2 * w) / LOAD_DTYPE(in_shape.shapes[3]));
     LOAD_DTYPE freqc = cos(f);
     LOAD_DTYPE freqs = sin(f);
 


### PR DESCRIPTION
- Corrected memory allocation for pipeline name to include space for the null terminator.
- Fixed push constant size calculation for RoPE pipelines to match shader struct layout.
- Updated RoPE shader to define base frequency as float.